### PR TITLE
Parsing resource IDs when given a full portal.azure.com URL

### DIFF
--- a/azurerm/helpers/azure/resourceid.go
+++ b/azurerm/helpers/azure/resourceid.go
@@ -34,8 +34,16 @@ func ParseAzureResourceID(id string) (*ResourceID, error) {
 
 	components := strings.Split(path, "/")
 
+  // If the path starts with #@ it is a structure like 
+  // #@location.onmicrosoft.com/resource/subscriptions/....
+  // This will break later by parsing too many segments so it would be good to
+  // strip it out of the array now and start with ['subscriptions', 'subscriptionID', ...]
+  if strings.HasPrefix(path, "#@") {
+    components = components[2:]
+  }
+
 	// We should have an even number of key-value pairs.
-	if len(components)%2 != 0 {
+	if len(components) % 2 != 0 {
 		return nil, fmt.Errorf("The number of path segments is not divisible by 2 in %q", path)
 	}
 

--- a/azurerm/internal/services/resource/group_parser_test.go
+++ b/azurerm/internal/services/resource/group_parser_test.go
@@ -42,6 +42,13 @@ func TestParseResourceGroup(t *testing.T) {
 			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.compute/virtualMachines/machine1",
 			Expected: nil,
 		},
+    {
+      Name:     "Full Resource Group URL as ID",
+      Input:    "https://portal.azure.com/#@location.onmicrosoft.com/resource/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+      Expected: &ResourceGroupResourceID{
+        Name: "foo",
+      },
+    },
 	}
 
 	for _, v := range testData {


### PR DESCRIPTION
Fixes #6585

Strips out the Azure portal location and "resource" identifier if the full URL for the resource identifier is provided.

This will fix cases where the Terraform resource ID is the full Azure URL rather than just the subscription-scoped Azure resource ID.